### PR TITLE
Fix authentication workspace creation error

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as auth from "../auth.js";
 import type * as comments from "../comments.js";
+import type * as debug from "../debug.js";
 import type * as tasks from "../tasks.js";
 import type * as users from "../users.js";
 import type * as workspaces from "../workspaces.js";
@@ -30,6 +31,7 @@ import type * as workspaces from "../workspaces.js";
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   comments: typeof comments;
+  debug: typeof debug;
   tasks: typeof tasks;
   users: typeof users;
   workspaces: typeof workspaces;


### PR DESCRIPTION
- Add proper ID validation to ensure Convex user ID is used for workspace creation
- Add comprehensive logging to trace the authentication flow
- Add error handling for workspace creation failures
- Validate that userId is not the same as auth0Id before creating workspace

The issue was that the Auth0 ID was being passed as createdBy instead of the Convex-generated user ID.