### PR TITLE
Fix authentication redirect loop and workspace name issues

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -23,6 +23,7 @@ export const syncUser = mutation({
     email: v.string(),
     name: v.string(),
     picture: v.optional(v.string()),
+    workspaceName: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     console.log("syncUser called with:", { auth0Id: args.auth0Id, email: args.email, name: args.name });
@@ -67,7 +68,7 @@ export const syncUser = mutation({
     let workspaceId;
     try {
       workspaceId = await ctx.db.insert("workspaces", {
-        name: `${args.name}'s Workspace`,
+        name: args.workspaceName || `${args.name}'s Workspace`,
         createdBy: userId,
         plan: "free",
         createdAt: new Date().toISOString(),

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -86,7 +86,7 @@ export const SignupForm: React.FC = () => {
       try {
         // TODO: Validate invitation code and join workspace
         await signup({ email, password, name });
-        navigate('/');
+        navigate('/dashboard');
       } catch (err: any) {
         setError(err.errorDescription || 'Failed to join workspace. Please check your invitation.');
       } finally {
@@ -116,7 +116,8 @@ export const SignupForm: React.FC = () => {
         plan: 'free'
       });
       setStep('complete');
-      setTimeout(() => navigate('/'), 2000);
+      // Let Auth0 callback handle the redirect
+      // The user will be redirected to /dashboard via the callback flow
     } catch (err: any) {
       setError(err.errorDescription || 'Failed to create account. Please try again.');
     } finally {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -76,7 +76,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
               auth0Id: auth0User.auth0Id,
               email: auth0User.email,
               name: auth0User.name || auth0User.email,
-              picture: auth0User.picture
+              picture: auth0User.picture,
+              workspaceName: auth0User.workspaceName
             });
             
             // syncUser now always creates a workspace for new users
@@ -144,7 +145,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 auth0Id: auth0User.auth0Id,
                 email: auth0User.email,
                 name: auth0User.name || auth0User.email,
-                picture: auth0User.picture
+                picture: auth0User.picture,
+                workspaceName: auth0User.workspaceName
               });
               
               // syncUser now always creates a workspace for new users
@@ -209,7 +211,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           auth0Id: auth0User.auth0Id,
           email: auth0User.email,
           name: auth0User.name || auth0User.email,
-          picture: auth0User.picture
+          picture: auth0User.picture,
+          workspaceName: auth0User.workspaceName
         });
       }
       

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -10,7 +10,7 @@ export const Landing: React.FC = () => {
   // If already authenticated, redirect to dashboard
   React.useEffect(() => {
     if (isAuthenticated) {
-      navigate('/');
+      navigate('/dashboard');
     }
   }, [isAuthenticated, navigate]);
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -89,6 +89,7 @@ class AuthService {
           picture: user.picture,
           emailVerified: user.email_verified,
           workspaceId: userAny['https://productivityapp.com/workspace_id'],
+          workspaceName: userAny['https://productivityapp.com/workspace_name'] || userAny.user_metadata?.workspaceName,
           role: userAny['https://productivityapp.com/role']
         });
       });

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -6,6 +6,7 @@ export interface AuthUser {
   avatar?: string;
   picture?: string;
   workspaceId?: string;
+  workspaceName?: string;
   role?: 'Admin' | 'Manager';
   emailVerified?: boolean;
 }


### PR DESCRIPTION
Root causes fixed:
1. Landing page had infinite redirect loop (redirecting to itself)
2. SignupForm was redirecting to Landing instead of Dashboard
3. User-entered workspace name was being ignored

Changes:
- Fixed Landing.tsx redirect to go to /dashboard instead of '/'
- Updated SignupForm to redirect to /dashboard after signup
- Removed setTimeout redirect to let Auth0 callback handle flow
- Added workspaceName parameter to syncUser mutation
- Updated auth service to retrieve workspace name from Auth0 metadata
- Pass workspace name through entire auth flow