### PR TITLE
fix: add missing auth0Id parameter to reorderTasks mutation

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -201,7 +201,8 @@ export const Dashboard: React.FC = () => {
       await reorderTasksMutation({
         taskId: taskId as Id<"tasks">,
         newStatus: columnIdToStatus(newColumnId),
-        newOrder: newOrder
+        newOrder: newOrder,
+        auth0Id: currentUser?.auth0Id
       });
       console.log(`Successfully moved task "${task.title}"`);
       


### PR DESCRIPTION
Fixes the 'Not authenticated' error when dragging tasks between columns. The reorderTasksMutation was missing the auth0Id parameter that is required by the Convex backend for authentication.
